### PR TITLE
Add translation for DHCP server disabled message

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -42,6 +42,8 @@
     "auth_password": "Password",
     "dns_server1": "Primary DNS server (optionnal)",
     "dns_server2": "Secondary DNS server (optionnal)",
+    "no_dhcp_server": "No DHCP server",
+    "no_dhcp_server_description": "The DHCP feature of piHole cannot be used.",
     "dns_server_is_running": "A DNS server is running",
     "dns_server_is_running_description": "You cannot configure pihole if a DNS server is already running on this node. A module like samba or dnsmasq may be using the DNS port."
   },

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -31,6 +31,16 @@
     </cv-row>
     <cv-row>
       <cv-column>
+        <NsInlineNotification
+          kind="info"
+          :title="$t('settings.no_dhcp_server')"
+          :description="$t('settings.no_dhcp_server_description')"
+          :showCloseButton="false"
+        />
+      </cv-column>
+    </cv-row>
+    <cv-row>
+      <cv-column>
         <cv-tile light>
           <cv-form @submit.prevent="configureModule">
             <cv-text-input


### PR DESCRIPTION
This pull request adds a translation for the message displayed when the DHCP server is disabled in the Settings view. The translation keys "no_dhcp_server" and "no_dhcp_server_description" are added to the translation file "translation.json" in the "ui/public/i18n/en" directory.