### PR TITLE
Update DNS server placeholders in Settings.vue

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -42,6 +42,7 @@
     "auth_password": "Password",
     "dns_server1": "Primary DNS server (optionnal)",
     "dns_server2": "Secondary DNS server (optionnal)",
+    "optional_dns_server": "Optional : set a custom DNS server",
     "no_dhcp_server": "No DHCP server",
     "no_dhcp_server_description": "The DHCP feature of piHole cannot be used.",
     "dns_server_is_running": "A DNS server is running",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -100,7 +100,7 @@
                 <template slot="content">
                   <cv-text-input
                     :label="$t('settings.dns_server1')"
-                    placeholder="9.9.9.9"
+                    :placeholder="$t('settings.optional_dns_server')"
                     v-model.trim="dns1"
                     class="mg-bottom"
                     :invalid-message="$t(error.dns1)"
@@ -112,7 +112,7 @@
                   </cv-text-input>
                   <cv-text-input
                     :label="$t('settings.dns_server2')"
-                    placeholder="8.8.8.8"
+                    :placeholder="$t('settings.optional_dns_server')"
                     v-model.trim="dns2"
                     class="mg-bottom"
                     :invalid-message="$t(error.dns2)"


### PR DESCRIPTION
This pull request updates the DNS server placeholders in the Settings.vue file to use the translated string "Optional : set a custom DNS server" from the translation file. The placeholders for both primary and secondary DNS servers are updated to display the translated string, providing a clearer instruction to the user.