### PR TITLE
Add firewall rules for DHCP services

### DIFF
--- a/imageroot/actions/create-module/70firewall
+++ b/imageroot/actions/create-module/70firewall
@@ -10,4 +10,5 @@ import agent
 
 agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], [
     "53/tcp", "53/udp", # DNS
+    "67/udp", "68/udp", # DHCP
     ]))

--- a/imageroot/actions/create-module/70firewall
+++ b/imageroot/actions/create-module/70firewall
@@ -10,5 +10,5 @@ import agent
 
 agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], [
     "53/tcp", "53/udp", # DNS
-    "67/udp", "68/udp", # DHCP
+    "67/udp" # DHCP
     ]))

--- a/imageroot/systemd/user/pihole-app.service
+++ b/imageroot/systemd/user/pihole-app.service
@@ -31,6 +31,8 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/pihole-app.pid \
     --env DNS2="${DNS2}" \
     --env DNSMASQ_LISTENING="local" \
     --env=PIHOLE_* \
+    --cap-add=NET_ADMIN \
+    --cap-add=NET_RAW \
     ${PIHOLE_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/pihole-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP pihole-app

--- a/imageroot/systemd/user/pihole.service
+++ b/imageroot/systemd/user/pihole.service
@@ -24,6 +24,7 @@ ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pihole.pid \
     --name pihole \
     --publish 127.0.0.1:${TCP_PORT}:80 \
     -p 53:53/udp -p 53:53/tcp \
+    -p 67:67/udp -p 68:68/udp \
     --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/pihole.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pihole.pod-id -t 10

--- a/imageroot/systemd/user/pihole.service
+++ b/imageroot/systemd/user/pihole.service
@@ -24,7 +24,7 @@ ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pihole.pid \
     --name pihole \
     --publish 127.0.0.1:${TCP_PORT}:80 \
     -p 53:53/udp -p 53:53/tcp \
-    -p 67:67/udp -p 68:68/udp \
+    -p 67:67/udp \
     --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/pihole.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pihole.pod-id -t 10


### PR DESCRIPTION
This pull request adds firewall rules for DHCP services. Specifically, it adds the necessary rules to allow communication on ports 67/udp and 68/udp, which are used for DHCP. This ensures that DHCP functionality is properly supported.

add NET_ADMIN and NET_RAW