### PR TITLE
Remove DNS1 and DNS2 environment variables

### DIFF
--- a/imageroot/actions/configure-module/10configure_environment_vars
+++ b/imageroot/actions/configure-module/10configure_environment_vars
@@ -13,5 +13,3 @@ data = json.load(sys.stdin)
 
 # this values must exists in the json stdin
 agent.set_env("WEBPASSWORD", data["webpassword"])
-agent.set_env("DNS1", data["dns1"])
-agent.set_env("DNS2", data["dns2"])

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -43,8 +43,6 @@ config['pihole_is_configured'] = True if os.getenv("WEBPASSWORD","") != "" else 
 
 config["dns_ports_bound"] = are_ports_53_bound()
 config["webpassword"] = os.getenv("WEBPASSWORD","Nethesis,1234")
-config["dns1"] = os.getenv("DNS1","")
-config["dns2"] = os.getenv("DNS2","")
 
 # Dump the configuration to stdout
 json.dump(config, fp=sys.stdout)

--- a/imageroot/systemd/user/pihole-app.service
+++ b/imageroot/systemd/user/pihole-app.service
@@ -27,8 +27,6 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/pihole-app.pid \
     --env IPv6="true" \
     --env dns="127.0.0.1" \
     --env dns="1.1.1.1" \
-    --env DNS1="${DNS1}" \
-    --env DNS2="${DNS2}" \
     --env DNSMASQ_LISTENING="local" \
     --env=PIHOLE_* \
     ${PIHOLE_IMAGE}

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -41,9 +41,9 @@
     "host_format": "Must be a valid fully qualified domain name",
     "auth_password": "Password",
     "no_dhcp_server": "Pi-hole's DHCP feature is disabled.",
-    "no_dhcp_server_description": "The DHCP feature of Pi-hole cannot be used. The IP address of the Pi-hole must be assigned by another DHCP server. Ensure that your network's DHCP server is configured to distribute the IP address of the Pi-hole so it can function as a DNS sinkhole.",
+    "no_dhcp_server_description": "The DHCP feature of Pihole cannot be used. The IP address of the server running Pihole must be assigned as the DNS server by another DHCP server. Ensure your network's DHCP server is configured to distribute this IP address for Pihole to function as the DNS sinkhole.",
     "dns_server_is_running": "A DNS server is running",
-    "dns_server_is_running_description": "You cannot configure pihole if a DNS server is already running on this node. A module like samba or dnsmasq may be using the DNS port."
+    "dns_server_is_running_description": "You cannot configure pihole if a DNS server is already running on this node. A module like samba, dnsmasq or another Pihole instance may be using the DNS port."
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -40,8 +40,6 @@
     "host_pattern": "Must be a valid fully qualified domain name",
     "host_format": "Must be a valid fully qualified domain name",
     "auth_password": "Password",
-    "dns_server1": "Primary DNS server (optionnal)",
-    "dns_server2": "Secondary DNS server (optionnal)",
     "no_dhcp_server": "Pi-hole's DHCP feature is disabled.",
     "no_dhcp_server_description": "The DHCP feature of Pi-hole cannot be used. The IP address of the Pi-hole must be assigned by another DHCP server. Ensure that your network's DHCP server is configured to distribute the IP address of the Pi-hole so it can function as a DNS sinkhole.",
     "dns_server_is_running": "A DNS server is running",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -42,8 +42,8 @@
     "auth_password": "Password",
     "dns_server1": "Primary DNS server (optionnal)",
     "dns_server2": "Secondary DNS server (optionnal)",
-    "no_dhcp_server": "No DHCP server",
-    "no_dhcp_server_description": "The DHCP feature of piHole cannot be used.",
+    "no_dhcp_server": "Pi-hole's DHCP feature is disabled.",
+    "no_dhcp_server_description": "The DHCP feature of Pi-hole cannot be used. The IP address of the Pi-hole must be assigned by another DHCP server. Ensure that your network's DHCP server is configured to distribute the IP address of the Pi-hole so it can function as a DNS sinkhole.",
     "dns_server_is_running": "A DNS server is running",
     "dns_server_is_running_description": "You cannot configure pihole if a DNS server is already running on this node. A module like samba or dnsmasq may be using the DNS port."
   },

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -49,7 +49,11 @@
               v-model.trim="host"
               class="mg-bottom"
               :invalid-message="$t(error.host)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                (dns_ports_bound && !pihole_is_configured)
+              "
               ref="host"
             >
             </cv-text-input>
@@ -57,7 +61,11 @@
               value="letsEncrypt"
               :label="$t('settings.lets_encrypt')"
               v-model="isLetsEncryptEnabled"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                (dns_ports_bound && !pihole_is_configured)
+              "
               class="mg-bottom"
             >
               <template slot="text-left">{{
@@ -71,7 +79,11 @@
               value="httpToHttps"
               :label="$t('settings.http_to_https')"
               v-model="isHttpToHttpsEnabled"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                (dns_ports_bound && !pihole_is_configured)
+              "
               class="mg-bottom"
             >
               <template slot="text-left">{{
@@ -89,7 +101,11 @@
               v-model.trim="webpassword"
               class="mg-bottom"
               :invalid-message="$t(error.webpassword)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                (dns_ports_bound && !pihole_is_configured)
+              "
               ref="webpassword"
             >
             </cv-text-input>
@@ -174,7 +190,7 @@ export default {
         host: "",
         lets_encrypt: "",
         http2https: "",
-        webpassword: ""
+        webpassword: "",
       },
     };
   },
@@ -321,7 +337,7 @@ export default {
             host: this.host,
             lets_encrypt: this.isLetsEncryptEnabled,
             http2https: this.isHttpToHttpsEnabled,
-            webpassword: this.webpassword
+            webpassword: this.webpassword,
           },
           extra: {
             title: this.$t("settings.instance_configuration", {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -94,37 +94,13 @@
             >
             </cv-text-input>
             <!-- advanced options -->
-            <cv-accordion ref="accordion" class="maxwidth mg-bottom">
+            <!-- <cv-accordion ref="accordion" class="maxwidth mg-bottom">
               <cv-accordion-item :open="toggleAccordion[0]">
                 <template slot="title">{{ $t("settings.advanced") }}</template>
                 <template slot="content">
-                  <cv-text-input
-                    :label="$t('settings.dns_server1')"
-                    placeholder="9.9.9.9"
-                    v-model.trim="dns1"
-                    class="mg-bottom"
-                    :invalid-message="$t(error.dns1)"
-                    :disabled="
-                      loading.getConfiguration || loading.configureModule
-                    "
-                    ref="dns1"
-                  >
-                  </cv-text-input>
-                  <cv-text-input
-                    :label="$t('settings.dns_server2')"
-                    placeholder="8.8.8.8"
-                    v-model.trim="dns2"
-                    class="mg-bottom"
-                    :invalid-message="$t(error.dns2)"
-                    :disabled="
-                      loading.getConfiguration || loading.configureModule
-                    "
-                    ref="dns2"
-                  >
-                  </cv-text-input>
                 </template>
               </cv-accordion-item>
-            </cv-accordion>
+            </cv-accordion> -->
             <cv-row v-if="error.configureModule">
               <cv-column>
                 <NsInlineNotification
@@ -184,8 +160,6 @@ export default {
       urlCheckInterval: null,
       host: "",
       webpassword: "",
-      dns1: "",
-      dns2: "",
       pihole_is_configured: false,
       dns_ports_bound: false,
       isLetsEncryptEnabled: false,
@@ -200,9 +174,7 @@ export default {
         host: "",
         lets_encrypt: "",
         http2https: "",
-        webpassword: "",
-        dns1: "",
-        dns2: "",
+        webpassword: ""
       },
     };
   },
@@ -273,8 +245,6 @@ export default {
       this.pihole_is_configured = config.pihole_is_configured;
       this.dns_ports_bound = config.dns_ports_bound;
       this.webpassword = config.webpassword;
-      this.dns1 = config.dns1;
-      this.dns2 = config.dns2;
       this.loading.getConfiguration = false;
       this.focusElement("host");
     },
@@ -351,9 +321,7 @@ export default {
             host: this.host,
             lets_encrypt: this.isLetsEncryptEnabled,
             http2https: this.isHttpToHttpsEnabled,
-            webpassword: this.webpassword,
-            dns1: this.dns1,
-            dns2: this.dns2,
+            webpassword: this.webpassword
           },
           extra: {
             title: this.$t("settings.instance_configuration", {


### PR DESCRIPTION
This pull request removes the DNS1 and DNS2 environment variables from the configure-module and pihole-app.service files. These variables are no longer needed and can be safely removed.
