### PR TITLE
Update password handling for improved security

### DIFF
--- a/imageroot/actions/configure-module/10configure_environment_vars
+++ b/imageroot/actions/configure-module/10configure_environment_vars
@@ -12,4 +12,5 @@ import agent
 data = json.load(sys.stdin)
 
 # this values must exists in the json stdin
-agent.set_env("WEBPASSWORD", data["webpassword"])
+password = {"WEBPASSWORD":data["webpassword"]}
+agent.write_envfile("password.env", password)

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,10 +39,10 @@ def are_ports_53_bound(ip='127.0.0.1'):
     return is_port_bound(53, 'tcp', ip) and is_port_bound(53, 'udp', ip)
 
 # check if the piler service is running
-config['pihole_is_configured'] = True if os.getenv("WEBPASSWORD","") != "" else False
+config['pihole_is_configured'] = True if os.path.exists("password.env") else False
 
 config["dns_ports_bound"] = are_ports_53_bound()
-config["webpassword"] = os.getenv("WEBPASSWORD","Nethesis,1234")
+config["webpassword"] = agent.read_envfile("password.env")["WEBPASSWORD"] if os.path.exists("password.env") else "Nethesis,1234"
 
 # Dump the configuration to stdout
 json.dump(config, fp=sys.stdout)

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -6,3 +6,4 @@
 
 
 volumes/etc
+state/password.env

--- a/imageroot/systemd/user/pihole-app.service
+++ b/imageroot/systemd/user/pihole-app.service
@@ -11,6 +11,7 @@ After=pihole.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/password.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70


### PR DESCRIPTION
This pull request updates the password handling in the configure-module and get-configuration files. Instead of directly setting the "WEBPASSWORD" environment variable, the password is now stored in a separate "password.env" file. This improves security and separation of concerns.