### PR TITLE
fix(service): allow to request to any dns query

### DIFF
--- a/imageroot/systemd/user/pihole-app.service
+++ b/imageroot/systemd/user/pihole-app.service
@@ -27,7 +27,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/pihole-app.pid \
     --env VIRTUAL_HOST="${TRAEFIK_HOST}" \
     --env IPv6="true" \
     --env dns="1.1.1.1" \
-    --env DNSMASQ_LISTENING="all" \
+    --env FTLCONF_dns_listeningMode="all" \
     --env=PIHOLE_* \
     ${PIHOLE_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/pihole-app.ctr-id -t 10


### PR DESCRIPTION
This pull request includes a small but important change to the `imageroot/systemd/user/pihole-app.service` file. The change updates the environment variable used for DNS listening mode.

* [`imageroot/systemd/user/pihole-app.service`](diffhunk://#diff-272901e3344fd48d93341b77f282b668eda6091d049785d3cc850a4f70d14bacL30-R30): Changed the environment variable from `DNSMASQ_LISTENING` to `FTLCONF_dns_listeningMode` to reflect the updated configuration.